### PR TITLE
add in new method to support LA integration

### DIFF
--- a/scripts/mods/third_person_equipment/third_person_equipment_ext.lua
+++ b/scripts/mods/third_person_equipment/third_person_equipment_ext.lua
@@ -232,6 +232,17 @@ ThirdPersonEquipmentExtension.offset_unit_by_mesh = function(self, unit, item_ty
 	end
 end
 
+
+--[[
+	Methods Chief purpose is for supporting integration with Loremaster's Armoury mod.
+--]]
+ThirdPersonEquipmentExtension.add_skin_name_to_unit = function(self, unit, skin_name, hand)
+	if Unit.alive(unit) then
+		Unit.set_data(unit, "skin_name", skin_name)
+		Unit.set_data(unit, "hand_unit", hand.."_hand_unit")
+	end
+end
+
 ThirdPersonEquipmentExtension.add = function(self, slot_name, slot_data)
 
 	local weapon_template = slot_data.item_template
@@ -241,17 +252,18 @@ ThirdPersonEquipmentExtension.add = function(self, slot_name, slot_data)
 	local item_type = slot_data.item_data.item_type
 	local item_name = slot_data.item_data.name --for pickups
 	local material_settings = self:get_weapon_skin_material_settings(slot_data)
-	
+	local skin_name = slot_data.skin
+
 	if left_hand_unit_name then
 		local left_attach_tisch = weapon_template.left_hand_attachment_node_linking.third_person.unwielded
-		local left_unit = self:spawn(left_hand_unit_name .. "_3p", left_attach_tisch, "left", item_type, item_name)
+		local left_unit = self:spawn(left_hand_unit_name .. "_3p", left_attach_tisch, "left", item_type, item_name, skin_name)
 		self:apply_skin_material_settings(left_unit, material_settings)
 		self.weapons[left_unit] = slot_name
 	end
 
 	if right_hand_unit_name then
 		local right_attach_tisch = weapon_template.right_hand_attachment_node_linking.third_person.unwielded
-		right_unit =self:spawn(right_hand_unit_name .. "_3p", right_attach_tisch, "right", item_type, item_name)
+		right_unit =self:spawn(right_hand_unit_name .. "_3p", right_attach_tisch, "right", item_type, item_name, skin_name)
 		self:apply_skin_material_settings(right_unit, material_settings)
 		self.weapons[right_unit] = slot_name
 	end
@@ -260,12 +272,14 @@ ThirdPersonEquipmentExtension.add = function(self, slot_name, slot_data)
     self:set_equipment_visibility()
 end
 
-ThirdPersonEquipmentExtension.spawn = function(self, unit_name, attachment_node_tisch, hand, item_type, item_name)
+ThirdPersonEquipmentExtension.spawn = function(self, unit_name, attachment_node_tisch, hand, item_type, item_name, skin_name)
 	
     local item_unit = Managers.state.unit_spawner:spawn_local_unit(unit_name)
 	
 	-- Add to spawned units
     mod.spawned_units[item_unit] = item_unit
+
+	self:add_skin_name_to_unit(item_unit, skin_name, hand)
 	-- Link unit
 	self:offset_unit_by_mesh(item_unit, item_type, attachment_node_tisch, hand, item_name)
 


### PR DESCRIPTION
Adds in a new method that tags spawned in units with data signifying their hand and skin used so Loremaster's Armoury's retexturing feature can easily find these units.